### PR TITLE
Week 11.5 - Handling failed jobs

### DIFF
--- a/app/Jobs/AnnounceNewAlbum.php
+++ b/app/Jobs/AnnounceNewAlbum.php
@@ -12,6 +12,7 @@ use App\Models\Album;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
 use App\Mail\NewAlbum;
+use Exception;
 
 class AnnounceNewAlbum implements ShouldQueue
 {
@@ -39,7 +40,11 @@ class AnnounceNewAlbum implements ShouldQueue
         $users = User::all();
 
         foreach ($users as $user) {
-            Mail::to($user->email)->send(new NewAlbum($this->album));
+            if ($user->email) {
+                Mail::to($user->email)->send(new NewAlbum($this->album));
+            } else {
+                throw new Exception("User {$user->id} is missing an email");
+            }
         }
     }
 }


### PR DESCRIPTION
After you've updated your code to what is in this PR, do the following:

1. Terminal tab 1: `php artisan queue:work`
2. Make sure there is at least 1 user. Remove the email address from at least one of the users. This will cause a job to fail, which is what we want.
3. Visit http://localhost/mail (or http://localhost:8000/mail for those not using Sail). This will dispatch the job. You will shortly see some failed jobs.
4. Add back the email to the user(s).
5. Terminal tab 2: `php artisan queue:retry all`. See other options for this command by running `php artisan help queue:retry`.
6. You should see that the failed jobs have been successfully processed.

In this example, when a failed jobs is retried, it will query for all of the users and send each one an email, even to those who received an email the first time. You'd probably want to add some extra code here to ensure users aren't sent the same email.

Another similar example would be dispatching a job that sends a monthly invoice to all of your customers.