### PR TITLE
Week 12.4 - Creating an album (POST /albums)

### DIFF
--- a/app/Http/Controllers/Api/AlbumController.php
+++ b/app/Http/Controllers/Api/AlbumController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Album;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 class AlbumController extends Controller
 {
@@ -27,7 +28,18 @@ class AlbumController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $validation = Validator::make($request->all(), [
+            'title' => 'required',
+            'artist_id' => 'required',
+        ]);
+
+        if ($validation->fails()) {
+            return response()->json([
+                'errors' => $validation->errors(),
+            ], 422);
+        }
+
+        return Album::create($request->all());
     }
 
     /**

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -10,6 +10,8 @@ class Album extends Model
 {
     use HasFactory;
 
+    protected $fillable = ['title', 'artist_id'];
+
     public function artist()
     {
         // albums.artist_id is the foregin key column


### PR DESCRIPTION
## Notes

1. In Postman, be sure to set the `Accept` header to `application/json` for a JSON response.
2. In Postman, set the `Content-Type` header to `application/json` so that Laravel knows the request body contains JSON and parses it correctly when you use `$request->input()`. See [retrieving JSON input values](https://laravel.com/docs/master/requests#retrieving-json-input-values) in the Laravel Documentation.

Sample request body:

```json
{"title":"Test album","artist_id":1}
```