### PR TITLE
Week 12.6 - Updating an album (PUT /albums/{id})

### DIFF
--- a/app/Http/Controllers/Api/AlbumController.php
+++ b/app/Http/Controllers/Api/AlbumController.php
@@ -68,9 +68,29 @@ class AlbumController extends Controller
      * @param  \App\Models\Album  $album
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, Album $album)
+    public function update(Request $request, $id)
     {
-        //
+        $album = Album::find($id);
+
+        if (!$album) {
+            return response()->json([
+                'error' => 'Album not found',
+            ], 404);
+        }
+
+        $validation = Validator::make($request->all(), [
+            'title' => 'required',
+            'artist_id' => 'required',
+        ]);
+
+        if ($validation->fails()) {
+            return response()->json([
+                'errors' => $validation->errors(),
+            ], 422);
+        }
+
+        $album->update($request->all());
+        return $album;
     }
 
     /**

--- a/app/Http/Controllers/Api/AlbumController.php
+++ b/app/Http/Controllers/Api/AlbumController.php
@@ -60,16 +60,8 @@ class AlbumController extends Controller
      * @param  \App\Models\Album  $album
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(Request $request, Album $album)
     {
-        $album = Album::find($id);
-
-        if (!$album) {
-            return response()->json([
-                'error' => 'Album not found',
-            ], 404);
-        }
-
         $validation = Validator::make($request->all(), [
             'title' => 'required',
             'artist_id' => 'required',


### PR DESCRIPTION
## Notes

1. In Postman, be sure to set the `Accept` header to `application/json` for a JSON response.
2. In Postman, set the `Content-Type` header to `application/json` so that Laravel knows the request body contains JSON and parses it correctly when you use `$request->input()`. See [retrieving JSON input values](https://laravel.com/docs/master/requests#retrieving-json-input-values) in the Laravel Documentation.

Sample request body:

```json
{"title":"Test album","artist_id":1}
```